### PR TITLE
feat: add `QFlags`, `QDir`, `QFileInfo`, and `QFile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Normally you don't have to do anything, the natvis files are copied in a central
 
 See documentation here: [Natvis file locations](https://learn.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects?view=vs-2022#BKMK_natvis_location)
 
+Some visulaizers require debug symbols for Qt to be loaded. To load them, add the `bin` directory of your Qt installation (e.g. `C:\Qt\6.8.0\msvc2022_64\bin`) to the symbol search path under **Options > Debugging > Symbols**.
+
 ### Visual Studio Code
 
 In order to use this natvis file in VS Code, you need to add a `visualizerFile` to your launch configuration. Edit your `launch.json` file (or the `launch` section of your `*.code-workspace` file) and add something like that:
@@ -69,6 +71,9 @@ In order to use this natvis file in VS Code, you need to add a `visualizerFile` 
                 "Q:/qt5_workdir/w/s": "${env:QTDIR}/../Src",
                 "C:/Users/qt/work/install": "${env:QTDIR}/../Src",
                 "C:/Users/qt/work/qt": "${env:QTDIR}/../Src"
+            },
+            "symbolOptions": {
+                "searchPaths": ["${env:QTDIR}/bin"],
             }
         }
     ]

--- a/natvis/qt6-extension.natvis
+++ b/natvis/qt6-extension.natvis
@@ -89,4 +89,39 @@
         </Expand>
     </Type>
 
+    <Type Name="QFlags&lt;*&gt;">
+        <DisplayString>{($T1)i}</DisplayString>
+        <Expand>
+            <Item Name="[value]">($T1)i</Item>
+        </Expand>
+    </Type>
+
+    <!-- The following types require debug symbols to be loaded. -->
+    <Type Name="QDir">
+        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Cored.dll!QDirPrivate**)&amp;d_ptr"></Intrinsic>
+        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Core.dll!QDirPrivate**)&amp;d_ptr"></Intrinsic>
+        <DisplayString>{d()-&gt;dirEntry.m_filePath}</DisplayString>
+        <Expand>
+            <ExpandedItem>d()</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="QFileInfo">
+        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Cored.dll!QFileInfoPrivate**)&amp;d_ptr"></Intrinsic>
+        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Core.dll!QFileInfoPrivate**)&amp;d_ptr"></Intrinsic>
+        <DisplayString>{d()-&gt;fileEntry.m_filePath}</DisplayString>
+        <Expand>
+            <ExpandedItem>d()</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="QFile">
+        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Cored.dll!QFilePrivate**)&amp;d_ptr"></Intrinsic>
+        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Core.dll!QFilePrivate**)&amp;d_ptr"></Intrinsic>
+        <DisplayString>{d()-&gt;fileName}</DisplayString>
+        <Expand>
+            <ExpandedItem>d()</ExpandedItem>
+        </Expand>
+    </Type>
+
 </AutoVisualizer>


### PR DESCRIPTION
These are so tiny, I combined them.

- **QFlags**: The types were changed from 6.8.x to 6.9, but the layout is the same (as well as the value name). Since Qt stores the value as an integer, it needs to be cast to the enum. I wonder why they aren't in the "official" natvis.
- **QDir** and friends show the directory/file name in the display string and expand to the private data, since they only consist of one pointer. They require debug symbols to be loaded. I tested them in debug and release mode.