### PR TITLE
fix(natvis): various fixes for Qt 6 and 6.9.0 compat

### DIFF
--- a/natvis/qt6-extension.natvis
+++ b/natvis/qt6-extension.natvis
@@ -8,11 +8,11 @@
     *************************************************************************************************-->
 
     <Type Name="QHostAddress">
-        <Intrinsic Name="a" Expression="((quint32*)d.d)[12]" />
-        <Intrinsic Name="a6" Expression="((unsigned char*)d.d)[32+offset]">
+        <Intrinsic Name="a" Expression="(*(quint32**)&amp;d)[12]" />
+        <Intrinsic Name="a6" Expression="(*(unsigned char**)&amp;d)[32+offset]">
             <Parameter Name="offset" Type="quint8" />
         </Intrinsic>
-        <Intrinsic Name="protocol" Expression="((char*)d.d)[52]" />
+        <Intrinsic Name="protocol" Expression="(*(char**)&amp;d)[52]" />
         <Intrinsic Name="isIpv4"
             Expression="protocol()==QAbstractSocket::NetworkLayerProtocol::IPv4Protocol" />
         <Intrinsic Name="isIpv6"
@@ -38,7 +38,7 @@
             short)(lshift(0xffff&amp;a6(14),8)|a6(15)),nvoXb}
         </DisplayString>
         <Expand>
-            <Item Name="scopeId">*((QString*)(((char*)d.d)+8))</Item>
+            <Item Name="scopeId">*((QString*)((*(char**)&amp;d)+8))</Item>
             <Item Name="protocol">(QAbstractSocket::NetworkLayerProtocol)protocol()</Item>
         </Expand>
     </Type>
@@ -72,20 +72,24 @@
     </Type>
 
     <Type Name="QImage">
-        <DisplayString Condition="d" Optional="true">{{ {d-&gt;width}x{d-&gt;height} }}</DisplayString>
+        <Intrinsic Name="p" Optional="true" Expression="(Qt6Guid.dll!QImageData*)d"></Intrinsic>
+        <Intrinsic Name="p" Optional="true" Expression="(Qt6Gui.dll!QImageData*)d"></Intrinsic>
+        <DisplayString Condition="d" Optional="true">{{ {p()-&gt;width}x{p()-&gt;height} }}</DisplayString>
         <DisplayString>empty</DisplayString>
         <Expand>
-            <Item Condition="d" Optional="true" Name="[width]">d-&gt;width</Item>
-            <Item Condition="d" Optional="true" Name="[height]">d-&gt;height</Item>
+            <Item Condition="d" Optional="true" Name="[width]">p()-&gt;width</Item>
+            <Item Condition="d" Optional="true" Name="[height]">p()-&gt;height</Item>
         </Expand>
     </Type>
 
     <Type Name="QPixmap">
-        <DisplayString Condition="data.d" Optional="true">{{ {data.d-&gt;w}x{data.d-&gt;h} }}</DisplayString>
+        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Guid.dll!QPlatformPixmap**)&amp;data"></Intrinsic>
+        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Gui.dll!QPlatformPixmap**)&amp;data"></Intrinsic>
+        <DisplayString Condition="d()" Optional="true">{{ {d()-&gt;w}x{d()-&gt;h} }}</DisplayString>
         <DisplayString>empty</DisplayString>
         <Expand>
-            <Item Condition="data.d" Optional="true" Name="[width]">data.d-&gt;w</Item>
-            <Item Condition="data.d" Optional="true" Name="[height]">data.d-&gt;h</Item>
+            <Item Condition="d()" Optional="true" Name="[width]">d()-&gt;w</Item>
+            <Item Condition="d()" Optional="true" Name="[height]">d()-&gt;h</Item>
         </Expand>
     </Type>
 

--- a/natvis/qt6.natvis
+++ b/natvis/qt6.natvis
@@ -69,7 +69,17 @@
         <DisplayString Condition="isNull()">empty</DisplayString>
         <DisplayString Condition="!isNull()">{_q_value}</DisplayString>
         <Expand>
-            <Item Name=" " Condition="!isNull()">*value()</Item>
+            <ExpandedItem Condition="!isNull()">*value()</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="QBasicAtomicPointer&lt;void&gt;">
+        <Intrinsic Name="isNull" Expression="value()==0" />
+        <Intrinsic Name="value" Expression="_q_value.value()" />
+        <DisplayString Condition="isNull()">empty</DisplayString>
+        <DisplayString Condition="!isNull()">{_q_value}</DisplayString>
+        <Expand>
+            <ExpandedItem Condition="!isNull()">value()</ExpandedItem>
         </Expand>
     </Type>
 
@@ -132,58 +142,56 @@
     </Type>
 
    <Type Name="QPolygon">
-        <DisplayString>{{ size={d-&gt;size} }}</DisplayString>
+        <DisplayString>{{ size={d.size} }}</DisplayString>
         <Expand>
-            <Item Name="[referenced]">d-&gt;ref.atomic._q_value</Item>
+            <Item Name="[referenced]">d.d-&gt;ref_._q_value</Item>
             <ArrayItems>
-                <Size>d-&gt;size</Size>
-                <ValuePointer>(QPoint*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)</ValuePointer>
+                <Size>d.size</Size>
+                <ValuePointer>d.ptr</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
    <Type Name="QPolygonF">
-        <DisplayString>{{ size={d-&gt;size} }}</DisplayString>
+        <DisplayString>{{ size={d.size} }}</DisplayString>
         <Expand>
             <Item Name="[closed]">
-                d-&gt;size &gt; 0
-                &amp;&amp; ((((QPointF*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)[0]).xp
-                == (((QPointF*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)[d-&gt;size - 1]).xp)
-                &amp;&amp; ((((QPointF*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)[0]).yp
-                == (((QPointF*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)[d-&gt;size - 1]).yp)
+                d.size &gt; 0
+                    &amp;&amp; d.ptr[0].xp == d.ptr[d.size - 1].xp
+                    &amp;&amp; d.ptr[0].yp == d.ptr[d.size - 1].yp
             </Item>
-            <Item Name="[referenced]">d-&gt;ref.atomic._q_value</Item>
+            <Item Name="[referenced]">d.d-&gt;ref_._q_value</Item>
             <ArrayItems>
-                <Size>d-&gt;size</Size>
-                <ValuePointer>(QPointF*)((reinterpret_cast&lt;char*&gt;(d)) + d-&gt;offset)</ValuePointer>
+                <Size>d.size</Size>
+                <ValuePointer>d.ptr</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="QVector2D">
-        <DisplayString>{{ x = {xp}, y = {yp} }}</DisplayString>
+        <DisplayString>{{ x = {v[0]}, y = {v[1]} }}</DisplayString>
         <Expand>
-            <Item Name="[x]">xp</Item>
-            <Item Name="[y]">yp</Item>
+            <Item Name="[x]">v[0]</Item>
+            <Item Name="[y]">v[1]</Item>
         </Expand>
     </Type>
 
     <Type Name="QVector3D">
-        <DisplayString>{{ x = {xp}, y = {yp}, z = {zp} }}</DisplayString>
+        <DisplayString>{{ x = {v[0]}, y = {v[1]}, z = {v[2]} }}</DisplayString>
         <Expand>
-            <Item Name="[x]">xp</Item>
-            <Item Name="[y]">yp</Item>
-            <Item Name="[z]">zp</Item>
+            <Item Name="[x]">v[0]</Item>
+            <Item Name="[y]">v[1]</Item>
+            <Item Name="[z]">v[2]</Item>
         </Expand>
     </Type>
 
     <Type Name="QVector4D">
-        <DisplayString>{{ x = {xp}, y = {yp}, z = {zp}, w = {wp} }}</DisplayString>
+        <DisplayString>{{ x = {v[0]}, y = {v[1]}, z = {v[2]}, w = {v[3]} }}</DisplayString>
         <Expand>
-            <Item Name="[x]">xp</Item>
-            <Item Name="[y]">yp</Item>
-            <Item Name="[z]">zp</Item>
-            <Item Name="[w]">wp</Item>
+            <Item Name="[x]">v[0]</Item>
+            <Item Name="[y]">v[1]</Item>
+            <Item Name="[z]">v[2]</Item>
+            <Item Name="[w]">v[3]</Item>
         </Expand>
     </Type>
 
@@ -406,12 +414,14 @@
     </Type>
 
    <Type Name="QMap&lt;*,*&gt;">
-        <AlternativeType Name="QMultiMap&lt;*,*&gt;"/>
-        <DisplayString>{{ size={d.d-&gt;m._Mypair._Myval2._Myval2._Mysize} }}</DisplayString>
+        <AlternativeType Name="QMultiMap&lt;*,*&gt;" />
+        <Intrinsic Name="p" Optional="true" Expression="d.d.ptr"></Intrinsic> <!-- after 6.9 -->
+        <Intrinsic Name="p" Optional="true" Expression="d.d"></Intrinsic> <!-- before 6.9 -->
+        <DisplayString>{{ size={p()-&gt;m._Mypair._Myval2._Myval2._Mysize} }}</DisplayString>
         <Expand>
             <TreeItems>
-                <Size>d.d-&gt;m._Mypair._Myval2._Myval2._Mysize</Size>
-                <HeadPointer>d.d-&gt;m._Mypair._Myval2._Myval2._Myhead-&gt;_Parent</HeadPointer>
+                <Size>p()-&gt;m._Mypair._Myval2._Myval2._Mysize</Size>
+                <HeadPointer>p()-&gt;m._Mypair._Myval2._Myval2._Myhead-&gt;_Parent</HeadPointer>
                 <LeftPointer>_Left</LeftPointer>
                 <RightPointer>_Right</RightPointer>
                 <ValueNode Condition="_Isnil == 0" Name="[{_Myval.first}]">_Myval,view(MapHelper)</ValueNode>
@@ -419,15 +429,18 @@
         </Expand>
     </Type>
 
-   <Type Name="std::pair&lt;*, *&gt;" IncludeView="MapHelper">
-        <DisplayString>{second}</DisplayString>
-    </Type>
-
    <Type Name="QHashPrivate::Node&lt;*,*&gt;">
         <DisplayString>{value}</DisplayString>
         <Expand>
             <Item Name="key">key</Item>
             <Item Name="value">value</Item>
+        </Expand>
+    </Type>
+
+    <Type Name="QHashPrivate::Node&lt;*,QHashDummyValue&gt;">
+        <DisplayString>{key}</DisplayString>
+        <Expand>
+            <ExpandedItem>key</ExpandedItem>
         </Expand>
     </Type>
 

--- a/natvis/test/core_types.h
+++ b/natvis/test/core_types.h
@@ -33,7 +33,7 @@ public:
     SelectionFlags qFlags = SelectionFlag::SelectCurrent;
     QLine qLine = QLine(0, 0, 42, 42);
     QPoint qPoint = QPoint(24, 48);
-    QPointF qPointF = QPoint(24.5, 48.5);
+    QPointF qPointF = QPointF(24.5, 48.5);
     QRect qRect = QRect(5, 5, 42, 42);
     QRectF qRectF = QRectF(5.5, 5.5, 4.2, 4.2);
     QSize qSize = QSize(42, 42);

--- a/natvis/test/gui_types.h
+++ b/natvis/test/gui_types.h
@@ -23,7 +23,7 @@ public:
     QQuaternion qQuaternion = QQuaternion(0., 0., 0., 1.);
     QRegion qRegion = QRegion();
     QTransform qTransform = QTransform();
-    QVector2D qVector2D = QVector2D(42., 42.);
-    QVector3D qVector3D = QVector3D(42., 42., 42.);
-    QVector4D qVector4D = QVector4D(42., 42., 42., 42.);
+    QVector2D qVector2D = QVector2D(42., 43.);
+    QVector3D qVector3D = QVector3D(42., 43., 44.);
+    QVector4D qVector4D = QVector4D(42., 43., 44., 45.);
 };


### PR DESCRIPTION
A few types did have a display string/expand, but they still showed warnings/errors in the debugger.

- `QHostAddress`: Problem described in #19 - resolution: reinterpret `d` as a pointer (i.e. `*(Type**)&d`) which works on both pre and post 6.9.
- `QImage`: I'd say this worked accidentally when [used as a variable](https://github.com/narnaud/natvis4qt/blob/0c74ed4cf1fade395228ca624d2952b84b25edab/natvis/test/main.cpp#L26), because either MSVC or the debugger decided to interpret this as a `QImage` from `Qt6Gui(d).dll` instead of the test executable. I used the same "trick" as for `QFile/QDir`. Since `d` was taken as an identifier, I used `p`.
- `QPixmap`: Same as `QImage`.
- `QBasicAtomicPointer<T>`: Remove the `Name=" "` and turn it into an `ExpandedItem`. For void pointers, this needs an extra block. They're used somewhere inside a `QObject`, not sure where, but when I expanded the type, I got an error about dereferencing a void-pointer.
- `QPolygon(F)`: This shouldn't have worked before, because `QArrayDataPointer<T>` was changed from Qt 5 to Qt 6 to now store `d`, `ptr`, and `size` directly - this makes the visualizer more readable. Previously, the expression engine fell back to visualizing a `QList<T>` (I think).
- `QVector{2,3,4}D`: Changed their storage in Qt 5.12 to an array (https://github.com/qt/qtbase/commit/093cf19f1efdfbba3edb76547917a51e5b8cdba5).
- `QMap`: Used an optional intrinsic to handle both pre and post 6.9 versions.
- `std::pair`: The `MapHelper` view is already in the [STL natvis](https://github.com/microsoft/STL/blob/1f6e5b16ec02216665624c1e762f3732605cf2b4/stl/debugger/STL.natvis#L1276-L1278) - this generates a warning for a duplicate entry.
- `QHashPrivate::Node<T, QHashDummyValue>`: This is used in `QSet`. There, no `value` is present, so we can directly expand the `key`.

**Changes to headers**:
- Fixed typo in type of `coreTypes.qPointF`
- Changed values in `QVector{2,3,4}D` to verify order of fields.

Closes #19.