### PR TITLE
feat: add Image Watch support for QPixmap/QImage

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -142,13 +142,13 @@ Show the current status of different classes. If you are interested in one missi
 | QBrush                           |         | ❌      |
 | QCursor                          |         | ❌      |
 | QFont                            |         | ❌      |
-| QImage                           | 0.2     | ✅      |
+| QImage[^3]                       | 0.2     | ✅      |
 | QKeySequence                     |         | ❌      |
 | QMatrix4x4                       | 0.1     | ✅      |
 | QPalette                         |         | ❌      |
 | QPen                             |         | ❌      |
 | QPicture                         |         | ❌      |
-| QPixmap                          | 0.2     | ✅      |
+| QPixmap[^3]                      | 0.2     | ✅      |
 | QPolygon                         | 0.1     | ✅      |
 | QPolygonF                        | 0.1     | ✅      |
 | QQuaternion                      | 0.1     | ✅      |
@@ -165,3 +165,4 @@ Show the current status of different classes. If you are interested in one missi
 
 [^1]: Only in dynamic debug builds of Qt
 [^2]: This visualizer is complex. You might need to bump the recursion limit in the Visual Studio settings. There's no known setting for VS Code.
+[^3]: Has support for the Image Watch extension in Visual Studio if the image is RGB(A) with 32bits/pixel.

--- a/natvis/qt6-extension.natvis
+++ b/natvis/qt6-extension.natvis
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <UIVisualizer ServiceId="{A452AFEA-3DF6-46BB-9177-C0B08F318025}" Id="1"
+            MenuName="Add to Image Watch"/>
 
     <!--************************************************************************************************
     Copyright (C) Nic Holthaus
@@ -71,25 +73,37 @@
         </Expand>
     </Type>
 
+    <Type Name="QImage" Priority="Low">
+        <UIVisualizer ServiceId="{A452AFEA-3DF6-46BB-9177-C0B08F318025}" Id="1" />
+    </Type>
     <Type Name="QImage">
-        <Intrinsic Name="p" Optional="true" Expression="(Qt6Guid.dll!QImageData*)d"></Intrinsic>
-        <Intrinsic Name="p" Optional="true" Expression="(Qt6Gui.dll!QImageData*)d"></Intrinsic>
+        <Intrinsic Name="p" Optional="true" Expression="(qwindowsd.dll!QImageData*)d" />
+        <Intrinsic Name="p" Optional="true" Expression="(Qt6Guid.dll!QImageData*)d" />
+        <Intrinsic Name="p" Optional="true" Expression="(Qt6Gui.dll!QImageData*)d" />
         <DisplayString Condition="d" Optional="true">{{ {p()-&gt;width}x{p()-&gt;height} }}</DisplayString>
         <DisplayString>empty</DisplayString>
         <Expand>
-            <Item Condition="d" Optional="true" Name="[width]">p()-&gt;width</Item>
-            <Item Condition="d" Optional="true" Name="[height]">p()-&gt;height</Item>
+            <Item Optional="true" Name="[width]">p()-&gt;width</Item>
+            <Item Optional="true" Name="[height]">p()-&gt;height</Item>
+            <Item Optional="true" Name="[data]">p()-&gt;data,[p()-&gt;bytes_per_line * p()-&gt;height]</Item>
+            <Item Optional="true" Name="[stride]">p()-&gt;bytes_per_line</Item>
+            <Synthetic Name="[type]">
+                <DisplayString>UINT8</DisplayString>
+            </Synthetic>
+            <Item Optional="true" Name="[channels]">p()-&gt;bytes_per_line / p()-&gt;width</Item>
         </Expand>
     </Type>
 
+    <Type Name="QPixmap" Priority="Low">
+        <UIVisualizer ServiceId="{A452AFEA-3DF6-46BB-9177-C0B08F318025}" Id="1" />
+    </Type>
     <Type Name="QPixmap">
-        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Guid.dll!QPlatformPixmap**)&amp;data"></Intrinsic>
-        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Gui.dll!QPlatformPixmap**)&amp;data"></Intrinsic>
+        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Guid.dll!QRasterPlatformPixmap**)&amp;data" />
+        <Intrinsic Name="d" Optional="true" Expression="*(Qt6Gui.dll!QRasterPlatformPixmap**)&amp;data" />
         <DisplayString Condition="d()" Optional="true">{{ {d()-&gt;w}x{d()-&gt;h} }}</DisplayString>
         <DisplayString>empty</DisplayString>
         <Expand>
-            <Item Condition="d()" Optional="true" Name="[width]">d()-&gt;w</Item>
-            <Item Condition="d()" Optional="true" Name="[height]">d()-&gt;h</Item>
+            <ExpandedItem>d()-&gt;image</ExpandedItem>
         </Expand>
     </Type>
 


### PR DESCRIPTION
As explained in #26.

- `QBitmap` can't be viewed, because Image Watch can't display indexed formats.
- Another funny bug(?): You need to put the natvis files into the user-local `Visualizers/` directory for it to work, otherwise you get `[invalid]`, because the extension doesn't scan the files in the solution directory (I wonder why it needs to scan at all).

Closes #26.