### PR TITLE
fix(qmap): Order `Intrinsic`s correctly for 6.9.0

### DIFF
--- a/natvis/qt6.natvis
+++ b/natvis/qt6.natvis
@@ -413,8 +413,8 @@
 
    <Type Name="QMap&lt;*,*&gt;">
         <AlternativeType Name="QMultiMap&lt;*,*&gt;" />
-        <Intrinsic Name="p" Optional="true" Expression="d.d.ptr"></Intrinsic> <!-- after 6.9 -->
         <Intrinsic Name="p" Optional="true" Expression="d.d"></Intrinsic> <!-- before 6.9 -->
+        <Intrinsic Name="p" Optional="true" Expression="d.d.ptr"></Intrinsic> <!-- after 6.9 -->
         <DisplayString>{{ size={p()-&gt;m._Mypair._Myval2._Myval2._Mysize} }}</DisplayString>
         <Expand>
             <TreeItems>


### PR DESCRIPTION
Seems like I messed that up - the docs say that [the last intrinsic wins](https://learn.microsoft.com/en-us/visualstudio/debugger/implementing-natvis-intrinsic-function?view=vs-2022#guidelines-for-using-an-intrinsic-function). For 6.9.0, both were valid, but we want the one with `d.d.ptr`.