### PR TITLE
fix(QDateTime): adjust for off-by-one error in year

### DIFF
--- a/natvis/qt6-extension.natvis
+++ b/natvis/qt6-extension.natvis
@@ -141,7 +141,7 @@
         <Intrinsic Name="mp"    Expression="(5*doy() + 2)/153"/>
         <Intrinsic Name="day"   Expression="doy() - (153*mp()+2)/5 + 1"/>
         <Intrinsic Name="month" Expression="mp() &lt; 10 ? mp()+3 : mp()-9"/>
-        <Intrinsic Name="year"  Expression="((long long)yoe()) + era() * 400 + (month() &lt; 2)"/>
+        <Intrinsic Name="year"  Expression="((long long)yoe()) + era() * 400 + (month() &lt;= 2)"/>
 
         <DisplayString ExcludeView="RecZone;RecZoneAbs">
             {year(),d}-{month()/10,d}{month()%10,d}-{day()/10,d}{day()%10,d} {


### PR DESCRIPTION
Originally fixed in https://redirect.github.com/microsoft/STL/pull/5389 - missed a `=` in the year calculation, which caused it to be off-by-one in February.