### PR TITLE
Fix QVariant natvis

### DIFF
--- a/natvis/qt6.natvis
+++ b/natvis/qt6.natvis
@@ -882,7 +882,7 @@ SPDX-License-Identifier: MIT
         <DisplayString Condition="typeId() == QMetaType::QColorSpace">QColorSpace</DisplayString>
 
         <!-- Static widget classes -->
-        <DisplayString Condition="typeId() == QMetaType::QSizePolicy">{*(QSizePolicy*) dataStar()}</DisplayString>
+        <DisplayString Condition="typeId() == QMetaType::QSizePolicy">QSizePolicy</DisplayString>
 
         <!-- Unhandled : display the typeId-->
         <DisplayString>QMetaType::Type ({typeId()})</DisplayString>


### PR DESCRIPTION
For me the natvis file didn't work properly on VS2022 with Qt6 until I made this change to the QVariant natvis file.